### PR TITLE
Handle \ on Windows, normalize to /

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,14 @@ var htmlJsStr = require('js-string-escape');
 function templateCache(root) {
 	return es.map(function(file, cb) {
 		var template = '$templateCache.put("<%= url %>","<%= contents %>");';
+		var url = path.join(root, file.path.replace(file.base, ''));
+
+		if (process.platform === 'win32') {
+			url = url.replace(/\\/g, '/');
+		}
 
 		file.contents = new Buffer(gutil.template(template, {
-			url: path.join(root, file.path.replace(file.base, '')),
+			url: url,
 			contents: htmlJsStr(file.contents),
 			file: file
 		}));


### PR DESCRIPTION
The templatecache url should be normalized, otherwise things will fail depending on which os you use to build the templates.

Wasn't sure about the best way to test this, as it relies on setting `path.sep` to `\`. Might have time to look at it later this week.
