### PR TITLE
Enable reuse of existing module

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,14 +27,15 @@ module.exports = function(filename, options) {
 	}
 	options = options || {};
 
-	var templateHeader = 'angular.module("<%= module %>", []).run(["$templateCache", function($templateCache) {';
+	var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
 	var templateFooter = '}]);'
 
 	return es.pipeline(
 		templateCache(options.root || ''),
 		concat(filename),
 		header(templateHeader, {
-			module: options.module || 'templates'
+			module: options.module || 'templates',
+			standalone: options.standalone ? ', []' : ''
 		}),
 		footer(templateFooter)
 	)

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ it('should build valid $templateCache from two html-files', function(cb) {
 	stream.on('data', function(file) {
 		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
 		assert.equal(file.relative, 'templates.js');
-		assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");\n$templateCache.put("/template-b.html","<h1 id=\\"template-b\\">I\\\'m template B!</h1>");}]);');
+		assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");\n$templateCache.put("/template-b.html","<h1 id=\\"template-b\\">I\\\'m template B!</h1>");}]);');
 		cb();
 	});
 
@@ -35,7 +35,28 @@ it('should set proper template urls using options.root', function(cb) {
 	stream.on('data', function(file) {
 		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
 		assert.equal(file.relative, 'templates.js');
-		assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+		assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: '~/dev/projects/gulp-angular-templatecache/test',
+		path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
+		contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+	}));
+
+	stream.end();
+});
+
+it('should be able to create standalone module', function(cb) {
+	var stream = templateCache('templates.js', {
+		standalone: true
+	});
+
+	stream.on('data', function(file) {
+		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
+		assert.equal(file.relative, 'templates.js');
+		assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
 		cb();
 	});
 


### PR DESCRIPTION
I usually want to add my templates to an existing module instead of creating a standalone `templates` module. This change is inspired by [grunt-angular-templates](https://github.com/ericclemmons/grunt-angular-templates)'s handling of the same issue, so this is a breaking change as it defaults to not creating a standalone module.
