### PR TITLE
make filename optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,13 @@ function templateCache(root) {
 }
 
 module.exports = function(filename, options) {
-	if (!filename) {
-		throw new PluginError('gulp-angular-templatecache', 'Missing filename option for gulp-angular-templatecache');
+	if (typeof filename === 'string') {
+		options = options || {};
+	} else {
+		// filename is not a string, so it's either undefined or our options
+		options = filename || {};
+		filename = 'templates.js';
 	}
-	options = options || {};
 
 	var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
 	var templateFooter = '}]);'

--- a/test.js
+++ b/test.js
@@ -68,3 +68,43 @@ it('should be able to create standalone module', function(cb) {
 
 	stream.end();
 });
+
+it('defaults to templates.js if no filename is specified', function(cb) {
+	var stream = templateCache();
+
+	stream.on('data', function(file) {
+		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
+		assert.equal(file.relative, 'templates.js');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: '~/dev/projects/gulp-angular-templatecache/test',
+		path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
+		contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+	}));
+
+	stream.end();
+});
+
+it('can specify options as first parameter when no filename is specified', function(cb) {
+	var stream = templateCache({
+		standalone: true,
+		root: '/views'
+	});
+
+	stream.on('data', function(file) {
+		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
+		assert.equal(file.relative, 'templates.js');
+		assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: '~/dev/projects/gulp-angular-templatecache/test',
+		path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
+		contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+	}));
+
+	stream.end();
+});


### PR DESCRIPTION
I've used this plugin in a couple of projects now, and I haven't yet needed the filename. My pattern:

``` javascript
function jsFiles() {
    return gulp.src('./some/path/**/*.js');
}
function angularTemplates() {
    return gulp.src('./some/path/**/*.html')
        .pipe(htmlmin())
        .pipe(templates('templates.js'));
}

gulp.task('js', function() {
    return es.concat(jsFiles(), angularTemplates())
        .pipe(concat('app.js'))
        .pipe(uglify())
        .pipe(gulp.dest('./build'));
});
```

So I never end up writing the templates file to any folder, it's just a temporary file. `templates.js` is unnecessary in this case.

In the pull request I've handled the following cases: 
- `templates()` => `filename = 'templates.js', options = {}`
- `templates(filename)` => `options = {}`
- `templates(options)` => `filename = 'templates.js'`
- `templates(filename, options)`

Not sure about this one, but it feels nice not having to specify an unnecessary parameter.
