### PR TITLE
feat: base path is relative to file's current path

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,10 @@ function templateCache(root, base) {
 
 	return es.map(function(file, cb) {
 		var template = '$templateCache.put("<%= url %>","<%= contents %>");';
-		var url = path.join(root, file.path.replace(base || file.base, ''));
+		var url = path.join(root, file.path.replace(file.base , ''));
+        if(base) {
+            url = path.join(root, file.path.replace(file.base + base, ''));
+        }
 
 		if (process.platform === 'win32') {
 			url = url.replace(/\\/g, '/');

--- a/test/test.js
+++ b/test/test.js
@@ -136,18 +136,18 @@ it('can override file base path in options', function(cb) {
 	var stream = templateCache({
 		standalone: true,
 		root: '/views',
-		base: '~/dev/projects/gulp-angular-templatecache'
+		base: 'test'
 	});
 
 	stream.on('data', function(file) {
-		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
+		assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/templates.js');
 		assert.equal(file.relative, 'templates.js');
-		assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/test/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+		assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
 		cb();
 	});
 
 	stream.write(new gutil.File({
-		base: '~/dev/projects/gulp-angular-templatecache/test',
+		base: '~/dev/projects/gulp-angular-templatecache/',
 		path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
 		contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
 	}));


### PR DESCRIPTION
The file base path is good in most cases. However when using a glob pattern to grab files it is helpful for the base option to be relative to the file streams current base path.

For example
When using a glob pattern `foo/**/*.html`
With a file `foo/bar/biz/baz.html`

You get a file stream of:
base: `foo/`
path: `foo/bar/biz/baz.html`

In this case passing a base option of `bar/biz/` will leave you with just `baz.html` when generating the template cache.
