### PR TITLE
Add option to create standalone node module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Include this file in your app and AngularJS will use the $templateCache when ava
 
 gulp-angular-templatecache([filename](#filename), [options](#options))
 
----- 
+----
 
 ### filename
 
@@ -90,6 +90,21 @@ Default: `templates`
 #### standalone (Boolean)
 
 > Create a new AngularJS module, instead of using an existing.
+
+Default: `false`
+
+#### standaloneModule (Boolean)
+
+> Create a new AngularJS node module, which is properly exported,
+> so you could use it in your browserify project.
+>
+> Example browserify angular app with template cache module:
+>
+> require('angular');
+>
+> var app = angular.module('app', [
+>   require('./templates_cache').name
+> ]).config(require('./routes'));
 
 Default: `false`
 

--- a/index.js
+++ b/index.js
@@ -36,8 +36,13 @@ module.exports = function(filename, options) {
 		filename = options.filename || 'templates.js';
 	}
 
-	var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
-	var templateFooter = '}]);';
+  var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
+  var templateFooter = '}]);';
+
+  if (options.standaloneModule) {
+    templateHeader = 'module.exports = ' + templateHeader;
+    options.standalone = true;
+  }
 
 	return es.pipeline(
 		templateCache(options.root || '', options.base),

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,27 @@ it('should be able to create standalone module', function(cb) {
 	stream.end();
 });
 
+it('should be able to create standalone node module properly exported', function(cb) {
+  var stream = templateCache('templates.js', {
+    standaloneModule: true
+  });
+
+  stream.on('data', function(file) {
+    assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/test/templates.js');
+    assert.equal(file.relative, 'templates.js');
+    assert.equal(file.contents.toString('utf8'), 'module.exports = angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+    cb();
+  });
+
+  stream.write(new gutil.File({
+    base: '~/dev/projects/gulp-angular-templatecache/test',
+    path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
+    contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+  }));
+
+  stream.end();
+});
+
 it('defaults to templates.js if no filename is specified', function(cb) {
 	var stream = templateCache();
 


### PR DESCRIPTION
For people using angular with browserify, adding this feature is
crucial so they could embed easily template caches in their build.

``` javascript
templateCache('templates_cache.js', {
  standaloneModule: true
});
```

So end result is valid node module, which could be used inside browserify app.

``` javascript
module.exports = angular.module("templates", []).run(["$templateCache", function($templateCache) {}]);
```

Here is a example app:

``` javascript
require('angular');

var app = angular.module('app', [
  require('./templates_cache').name
]);

app.config(require('./routes'));
```
