### PR TITLE
feat: base path for relative file uris

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,21 @@ var footer = require('gulp-footer');
 var htmlJsStr = require('js-string-escape');
 
 function templateCache(root, base) {
-  if (base && base.substr(-1) !== path.sep) {
-    base += path.sep;
-  }
+  if (base && base.substr(-1) != path.sep)
+    base += path.sep
 
-  return es.map(function(file, callback) {
+  return es.map(function(file, cb) {
     var template = '$templateCache.put("<%= url %>","<%= contents %>");';
-    var url = path.join(root, file.path.replace(base || file.base, ''));
+    var url = path.join(root, file.path.replace(file.base , ''));
+    if(base) {
+      //Handle absolute base uri
+      if(base[0] === "/" || base[0] === "~") {
+        url = path.join(root, file.path.replace(base, ''));
+      //Handle relative base uri
+      } else {
+        url = path.join(root, file.path.replace(file.base + base, ''));
+      }
+    }
 
     if (process.platform === 'win32') {
       url = url.replace(/\\/g, '/');
@@ -25,7 +33,7 @@ function templateCache(root, base) {
       file: file
     }));
 
-    callback(null, file);
+    cb(null, file);
   });
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -153,4 +153,26 @@ it('can override file base path in options', function(cb) {
   }));
 
   stream.end();
+})
+it('can override relative file base path in options', function(cb) {
+  var stream = templateCache({
+    standalone: true,
+    root: '/views',
+    base: 'test'
+  });
+
+  stream.on('data', function(file) {
+    assert.equal(file.path, '~/dev/projects/gulp-angular-templatecache/templates.js');
+    assert.equal(file.relative, 'templates.js');
+    assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+    cb();
+  });
+
+  stream.write(new gutil.File({
+    base: '~/dev/projects/gulp-angular-templatecache/',
+    path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
+    contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+  }));
+
+  stream.end();
 });


### PR DESCRIPTION
fixes #13
I addressed clkao's concerns that the original change would be breaking for absolute file uris.

The file base path is good in most cases. However when using a glob pattern to grab files it is helpful for the base option to be relative to the file streams current base path.

For example
When using a glob pattern foo/*_/_.html
With a file foo/bar/biz/baz.html

You get a file stream of:
base: foo/
path: foo/bar/biz/baz.html

In this case passing a base option of bar/biz/ will leave you with just baz.html when generating the template cache.

<!---
@huboard:{"order":16.0,"custom_state":""}
-->
