### PR TITLE
Dynamically prefix the urls with an angular variable/constant with options.var

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Include this file in your app and AngularJS will use the $templateCache when ava
 
 gulp-angular-templatecache([filename](#filename), [options](#options))
 
----- 
+----
 
 ### filename
 
@@ -104,6 +104,11 @@ Default: `false`
 
 Default: `file.base` (file path of the current file being processed)
 
+#### var (String)
+
+> Allows you to inject an angular variable/constant to dynamicly prefix the urls.
+
+Default: no prefix
 
 ## Changes
 

--- a/test/test.js
+++ b/test/test.js
@@ -155,3 +155,27 @@ it('can override file base path in options', function(cb) {
 
   stream.end();
 });
+
+
+it('should prefix the urls with the options.baseVar', function(cb) {
+  var stream = templateCache({
+    standalone: true,
+    base: '~/dev/',
+    var: 'WEBROOT'
+  });
+
+  stream.on('data', function(file) {
+    assert.equal(path.normalize(file.path), path.normalize('~/dev/templates.js'));
+    assert.equal(file.relative, 'templates.js');
+    assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", "WEBROOT", function($templateCache, WEBROOT) {$templateCache.put(WEBROOT+"template.html","The contents");}]);');
+    cb();
+  });
+
+  stream.write(new gutil.File({
+    base: '~/dev/',
+    path: '~/dev/template.html',
+    contents: new Buffer('The contents')
+  }));
+
+  stream.end();
+});


### PR DESCRIPTION
We use the php backend to configure the base url:

``` php
angular.module('app').constant('WEBROOT', <?php json_encode($webroot); ?>);
```

In development this becomes:

``` js
angular.module('app').constant('WEBROOT', 'http://localhost/example-site/public/');
```

And in production this becomes:

``` js
angular.module('app').constant('WEBROOT', 'http://example.com/');
```

Which is used to build the template and api urls: 

``` js
templateUrl: WEBROOT + 'views/template.html'
```

Without the options.var the $templateCache.put operation would only work in either production or development but not both.
