### PR TITLE
Leave dependencies on the module registration empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function(filename, options) {
     filename = options.filename || 'templates.js';
   }
 
-  var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
+  var templateHeader = 'angular.module("<%= module %>"<%= standalone %>, []).run(["$templateCache", function($templateCache) {';
   var templateFooter = '}]);';
 
   return es.pipeline(


### PR DESCRIPTION
Having no dependency array caused issues on angularjs 1.2.10
