### PR TITLE
normalize file paths to avoid conflicts in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ function templateCache(root, base) {
     var template = '$templateCache.put("<%= url %>","<%= contents %>");';
     var url;
 
+    file.path = path.normalize(file.path);
+
     if (typeof base === 'function') {
       url = path.join(root, base(file));
     } else {


### PR DESCRIPTION
Without normalize, the capitalization of the drive letter is not well defined in Node 0.11+.

Ideally this should be handled in `vinyl` or `vinyl-fs` (base libraries for gulp's file object), but for now this is a harmless fix.
