### PR TITLE
Implement withRequire functionality to append require angular module

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,16 +45,19 @@ module.exports = function(filename, options) {
     filename = options.filename || 'templates.js';
   }
 
-  var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
-  var templateFooter = '}]);';
+  var templateHeader = '<%= headerRequire %>angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
+  var templateFooter = '}]);<%= footerRequire %>';
 
   return es.pipeline(
     templateCache(options.root || '', options.base),
     concat(filename),
     header(templateHeader, {
       module: options.module || 'templates',
-      standalone: options.standalone ? ', []' : ''
+      standalone: options.standalone ? ', []' : '',
+      headerRequire: options.withRequire ? 'define([\'angular\'], function(angular) { \'use strict\'; return ' : ''
     }),
-    footer(templateFooter)
+    footer(templateFooter, {
+      footerRequire: options.withRequire ? '});' : ''
+    })
   );
 };

--- a/test/test.js
+++ b/test/test.js
@@ -181,3 +181,28 @@ it('can provide a function to override file base path in options', function(cb) 
 
   stream.end();
 });
+
+describe('withRequire functionality', function(){
+  
+  it('should append require header to the beginning and to the end', function(cb){
+
+    var stream = templateCache('templates.js', {
+      withRequire: true
+    });
+
+    stream.on('data', function(file) {
+      assert.equal(path.normalize(file.path), path.normalize('~/dev/projects/gulp-angular-templatecache/test/templates.js'));
+      assert.equal(file.relative, 'templates.js');
+      assert.equal(file.contents.toString('utf8'), 'define([\'angular\'], function(angular) { \'use strict\'; return angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);});');
+      cb();
+    });
+
+    stream.write(new gutil.File({
+      base: '~/dev/projects/gulp-angular-templatecache/test',
+      path: '~/dev/projects/gulp-angular-templatecache/test/template-a.html',
+      contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+    }));
+
+    stream.end();
+  });
+});


### PR DESCRIPTION
Hello Mickel,
First of all thank you for such awesome package. It saved me a lot of time!
At my application we are using RequireJs+Angular, so produced file is not completely valid for us. There are also should be correct header and footer at result angular module. It could be also done by gulp task. However I decided to add one more option to your module. So if withRequire option set to true - produced file would
 be valid RequireJs+Angular module.
Please have a look at my pull request, I'm free to contact and improvements.
