### PR TITLE
Remember what files have been processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,13 @@ function templateCache(root, base) {
     var template = '$templateCache.put("<%= url %>","<%= contents %>");';
     var url;
 
+    if (file.processedByTemplateCache) {
+        /* Object has already been processed, probably returned by gulp-remember.
+        */
+        callback(null, file);
+        return
+    }
+    file.processedByTemplateCache = true
     file.path = path.normalize(file.path);
 
     if (typeof base === 'function') {


### PR DESCRIPTION
Fixes #35

gulp-remember is useful if the templates are preprocessed by e.g jade.

As gulp-angular-templatecache is a process + concat, plugin, this gives issues.

gulp-remember caches the whole file object, but templateCache is overwritting the contents of that object.
When the stream re-runs without change to some files, the Buffer output by templateCache is resent as Input, which is not what we want.

Signed-off-by: Pierre Tardy <pierre.tardy@intel.com>