### PR TITLE
Fixed module declaration syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(filename, options) {
     filename = options.filename || 'templates.js';
   }
 
-  var templateHeader = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
+  var templateHeader = 'angular.module("<%= module %>"<%= standalone %>, []).run(["$templateCache", function($templateCache) {';
   var templateFooter = '}]);';
 
   return es.pipeline(


### PR DESCRIPTION
Angular attempts to fetch an existing module if when a module is declared without dependencies. I don't know when this was actually changed in Angular but I'm using 1.2.22.
