### PR TITLE
Added lodash.bind as project dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "js-string-escape": "~1.0.0",
     "gulp-footer": "1.x",
     "gulp-header": "1.x",
-    "gulp-concat": "2.x"
+    "gulp-concat": "2.x",
+    "lodash.bind": "*"
   },
   "devDependencies": {
     "mocha": "latest"


### PR DESCRIPTION
This is required by the gulp-footer dependency.  It is added here to prevent the long path error that can arise on windows. (Particularly in Visual Studio).

Discussed in [this issue](https://github.com/miickel/gulp-angular-templatecache/issues/62)
