### PR TITLE
add note for base option in example section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ __Note:__ if you use Visual Studio on Windows, you might encounter this error me
 
 This is most likely due to long path names, and can be fixed by adding `lodash.bind` as a dev dependecy in your package.json. Anyway, if you encounter this error, please drop a note in #62, and we might merge #63.
 
+__Note:__ following snippet shows how we can use base option to set template name using original file name.
+
+```js
+var path = require('path');
+
+...
+.pipe(templateCache(
+	{ base: function(file) {
+		return path.basename(file.path) }
+	}))
+...
+```
+
 
 ## API
 


### PR DESCRIPTION
It seems a little bit confuse about how to use base option if one doesn't familiar with event-stream plugin. Therefore, I add a snippet illustrate the signature of base function.