### PR TITLE
Exposing module name in templateFooter

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,9 @@ function templateCache(filename, options) {
       module: options.module || DEFAULT_MODULE,
       standalone: options.standalone ? ', []' : ''
     }),
-    footer(templateFooter),
+    footer(templateFooter, {
+      module: options.module || DEFAULT_MODULE
+    }),
     wrapInModule(options.moduleSystem)
   );
 


### PR DESCRIPTION
Expose the module name in the templateFooter to allow explicit export of the module by its name.