### PR TITLE
Support for templateBody override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ npm install gulp-angular-templatecache --save-dev
 var templateCache = require('gulp-angular-templatecache');
 
 gulp.task('default', function () {
-	return gulp.src('templates/**/*.html')
-		.pipe(templateCache())
-		.pipe(gulp.dest('public'));
+  return gulp.src('templates/**/*.html')
+    .pipe(templateCache())
+    .pipe(gulp.dest('public'));
 });
 ```
 
@@ -49,13 +49,13 @@ gulp.task('default', function () {
 ```js
 angular.module("templates").run([$templateCache,
   function($templateCache) {
-	$templateCache.put("template1.html",
-		// template1.html content (escaped)
-	);
-	$templateCache.put("template2.html",
-		// template2.html content (escaped)
-	);
-	// etc.
+  $templateCache.put("template1.html",
+    // template1.html content (escaped)
+  );
+  $templateCache.put("template2.html",
+    // template2.html content (escaped)
+  );
+  // etc.
   }
 ]);
 
@@ -110,6 +110,14 @@ gulp-angular-templatecache([filename](https://github.com/miickel/gulp-angular-te
 var TEMPLATE_HEADER = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
 ```
 
+#### templateBody {string} [templateBody=see below]
+
+> Override template body.
+
+```js
+var TEMPLATE_BODY = '$templateCache.put("<%= url %>","<%= contents %>");';
+```
+
 #### templateFooter {string} [templateFooter=see below]
 
 > Override template footer.
@@ -132,16 +140,16 @@ See [Releases](https://github.com/miickel/gulp-angular-templatecache/releases)
 > Cleaner code, more tests and improved documentation. Thoroughly used in development.
 
 - adds
-	- `options.standalone` (**breaking**)
+  - `options.standalone` (**breaking**)
 - fixes
-	- Windows support
+  - Windows support
 - changes
-	- `filename` now optional
+  - `filename` now optional
 
 ### 0.3.0
 
 - adds
-	- `options.module`
+  - `options.module`
 
 ### 0.2.0 and earlier
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ var htmlJsStr = require('js-string-escape');
  */
 
 var TEMPLATE_HEADER = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
+var TEMPLATE_BODY = '$templateCache.put("<%= url %>","<%= contents %>");';
 var TEMPLATE_FOOTER = '}]);';
+
 var DEFAULT_FILENAME = 'templates.js';
 var DEFAULT_MODULE = 'templates';
 var MODULE_TEMPLATES = {
@@ -36,14 +38,14 @@ var MODULE_TEMPLATES = {
  * Add files to templateCache.
  */
 
-function templateCacheFiles(root, base) {
+function templateCacheFiles(root, base, templateBody) {
 
   return function templateCacheFile(file, callback) {
     if (file.processedByTemplateCache) {
       return callback(null, file);
     }
 
-    var template = '$templateCache.put("<%= url %>","<%= contents %>");';
+    var template = templateBody || TEMPLATE_BODY;
     var url;
 
     file.path = path.normalize(file.path);
@@ -88,7 +90,7 @@ function templateCacheFiles(root, base) {
  * templateCache a stream of files.
  */
 
-function templateCacheStream(root, base) {
+function templateCacheStream(root, base, templateBody) {
 
   /**
    * Set relative base
@@ -102,7 +104,7 @@ function templateCacheStream(root, base) {
    * templateCache files
    */
 
-  return es.map(templateCacheFiles(root, base));
+  return es.map(templateCacheFiles(root, base, templateBody));
 
 }
 
@@ -165,7 +167,7 @@ function templateCache(filename, options) {
    */
 
   return es.pipeline(
-    templateCacheStream(options.root || '', options.base),
+    templateCacheStream(options.root || '', options.base, options.templateBody),
     concat(filename),
     header(templateHeader, {
       module: options.module || DEFAULT_MODULE,

--- a/test/test.js
+++ b/test/test.js
@@ -278,5 +278,30 @@ describe('gulp-angular-templatecache', function () {
 
   });
 
+  describe('options.templateBody', function () {
+
+    it('should override TEMPLATE_BODY', function (cb) {
+      var stream = templateCache('templates.js', {
+        templateBody: '$templateCache.put(\'<%= url %>\',\'<%= contents %>\');',
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put(\'/template-a.html\',\'yoo\');}]);');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('yoo')
+      }));
+
+      stream.end();
+    });
+
+  });
+
 
 });


### PR DESCRIPTION
Allow the user to specify the `templateBody` in addition to the `templateHeader` & `templateFooter`.
Useful for overriding quote style, line breaks, whatever else.

Updating README with `templateBody` documentation.

Unit test for `templateBody` option.