### PR TITLE
Fix removal of the '.' when used as the root

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ function templateCacheFiles(root, base) {
       url = path.join(root, file.path.replace(base || file.base, ''));
     }
 
+    if(root === '.' || root.indexOf('./') === 0) {
+      url = './' + url;
+    }
+
     /**
      * Normalize url (win only)
      */

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,69 @@ describe('gulp-angular-templatecache', function () {
       stream.end();
     });
 
+    it('should preserve the "./" if there is one in front of the root', function (cb) {
+      var stream = templateCache('templates.js', {
+        root: './'
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("./template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+      }));
+
+      stream.end();
+    });
+
+    it('should preserve the "." if there is one in front of the root', function (cb) {
+      var stream = templateCache('templates.js', {
+        root: '.'
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("./template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+      }));
+
+      stream.end();
+    });
+
+    it('should preserve the root as is, if the root folder name start with a "." character', function (cb) {
+      var stream = templateCache('templates.js', {
+        root: '.root/'
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put(".root/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+      }));
+
+      stream.end();
+    });
+
   });
 
 


### PR DESCRIPTION
Sometimes you actually need the `.` prefix. Node's `path.join` drops the `.` because it has no effect as far as the file system directory structure is concerned.

One particular case for needing the '.' is adherence to naming conventions of the new Angular router, which by default expects components to appear under a directory structure similar to `./components/my-component/my-component.html`.