### PR TITLE
add transformUrl option for complete control over resulting URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ gulp-angular-templatecache([filename](https://github.com/miickel/gulp-angular-te
 
 > Wrap the templateCache in a module system. Currently supported systems: `RequireJS`, `Browserify` and `IIFE` (Immediately-Invoked Function Expression).
 
+#### transformUrl {function}
+
+> Transform the generated URL before it's put into `$templateCache`.
+
+```js
+transformUrl: function(url) {
+	return url.replace(/\.tpl\.html$/, '.html')
+}
+```
+
 #### templateHeader {string} [templateHeader=see below]
 
 > Override template header.

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var MODULE_TEMPLATES = {
  * Add files to templateCache.
  */
 
-function templateCacheFiles(root, base) {
+function templateCacheFiles(root, base, transformUrl) {
 
   return function templateCacheFile(file, callback) {
     if (file.processedByTemplateCache) {
@@ -56,6 +56,10 @@ function templateCacheFiles(root, base) {
       url = path.join(root, base(file));
     } else {
       url = path.join(root, file.path.replace(base || file.base, ''));
+    }
+
+    if (typeof transformUrl === 'function') {
+      url = transformUrl(url);
     }
 
     /**
@@ -88,7 +92,7 @@ function templateCacheFiles(root, base) {
  * templateCache a stream of files.
  */
 
-function templateCacheStream(root, base) {
+function templateCacheStream(root, base, transformUrl) {
 
   /**
    * Set relative base
@@ -102,7 +106,7 @@ function templateCacheStream(root, base) {
    * templateCache files
    */
 
-  return es.map(templateCacheFiles(root, base));
+  return es.map(templateCacheFiles(root, base, transformUrl));
 
 }
 
@@ -165,7 +169,7 @@ function templateCache(filename, options) {
    */
 
   return es.pipeline(
-    templateCacheStream(options.root || '', options.base),
+    templateCacheStream(options.root || '', options.base, options.transformUrl),
     concat(filename),
     header(templateHeader, {
       module: options.module || DEFAULT_MODULE,

--- a/test/test.js
+++ b/test/test.js
@@ -80,6 +80,58 @@ describe('gulp-angular-templatecache', function () {
   });
 
 
+  describe('options.transformUrl', function () {
+
+    it('should change the URL to the output of the function', function (cb) {
+      var stream = templateCache('templates.js', {
+        transformUrl: function(url) {
+          return url.replace(/template/, 'tpl');
+        }
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/tpl-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+      }));
+
+      stream.end();
+    });
+
+    it('should set the final url, after any root option has been applied', function (cb) {
+      var stream = templateCache('templates.js', {
+        root: './views',
+        transformUrl: function(url) {
+          return '/completely/transformed/final';
+        }
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/completely/transformed/final","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+      }));
+
+      stream.end();
+    });
+
+  });
+
+
   describe('options.standalone', function () {
 
     it('should create standalone Angular module', function (cb) {


### PR DESCRIPTION
A `transformUrl` function can be passed to the plugin, which will be called with the generated URL, allowing full control over the final URL that's put into the `$templateCache`.

This is useful when one needs full control over the final URLs that go into the cache. I personally needed it because my angular template files have the extension `.tpl.html`, but I'd like to change that to `.html` when put into the cache, in order to meet expectations of the new Angular router without having to set a custom template mapping function.

I have to admit that for the particular use case above, I could have modified the source stream and transformed the path before it's piped through `gulp-angular-templatecache`, but having `transformUrl` is more convenient, and provides more fine-grained control over the final URL that's generated.