### PR TITLE
fixed absolute path in Windows when "base" option used

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function templateCacheFiles(root, base, templateBody, transformUrl) {
     if (typeof base === 'function') {
       url = path.join(root, base(file));
     } else {
-      url = path.join(root, file.path.replace(base || file.base, ''));
+      url = path.join(root, file.path.replace(path.normalize(base) || file.base, ''));
     }
 
     if (root === '.' || root.indexOf('./') === 0) {


### PR DESCRIPTION
Hi!

This code from my `gulpfile` works in Linux/Mac but not in Windows:
`.pipe(plugins.angularTemplatecache({base: 'src/app'}))`

Current module produces absolute paths when used in Windows. It happens because `/` is not normalized and absolute base path could't be cleaned from full path:
`d:\user\project\src\app\template.html`
`d:\user\project\src/app`