### PR TITLE
Lock gulp-header to avoid issue with 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-util": "3.x",
     "js-string-escape": "~1.0.0",
     "gulp-footer": "1.x",
-    "gulp-header": "1.x",
+    "gulp-header": "1.2",
     "gulp-concat": "2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
gulp-header 1.5.0 came out [today](https://github.com/tracker1/gulp-header/commit/ee853d00ac8c02d231abc2134a8db9838d6f40ad), and now when I try to use gulp-angular-templatecache, I get this error:

```
node_modules/gulp-angular-templatecache/node_modules/gulp-header/index.js:58
    var file = _file.clone({ contents: false });
                     ^
TypeError: Cannot call method 'clone' of undefined
```

Looks like maybe https://github.com/tracker1/gulp-header/pull/16 changed how files are handled? Everything sorts itself out when I lock to 1.2.2 (the last version before 1.5.0 on npm).