### PR TITLE
Add Multiple Roots Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ gulp-angular-templatecache([filename](https://github.com/miickel/gulp-angular-te
 
 ### options
 
-#### root - {string}
+#### root - {string|Array}
 
-> Prefix for template URLs.
+> Prefix for template URLs. May be an array of prefixes, to duplicate template across multiple domains.
 
 #### module - {string} [module='templates']
 

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,31 @@ describe('gulp-angular-templatecache', function () {
       stream.end();
     });
 
+    it('should set an array of roots', function (cb) {
+      var stream = templateCache('templates.js', {
+        root: ['/views', '/moreViews']
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(
+          file.contents.toString('utf8'),
+          'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");$templateCache.put("/moreViews/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);'
+        );
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
+      }));
+
+      stream.end();
+    });
+
+
     it('should preserve the "./" if there is one in front of the root', function (cb) {
       var stream = templateCache('templates.js', {
         root: './'


### PR DESCRIPTION
I ran into an i18n issue where I needed to duplicate the $templateCache for differing contexts i.e. us/, eu/, aus/, etc. I updated this plugin to support multiple roots, added an additional unit test to capture this functionality and updated the README.