### PR TITLE
reduce escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ var jsesc = require('jsesc');
  * "constants"
  */
 
-var TEMPLATE_HEADER = "angular.module('<%= module %>'<%= standalone %>).run(['$templateCache', function($templateCache) {";
-var TEMPLATE_BODY = "$templateCache.put('<%= url %>','<%= contents %>'); ";
-var TEMPLATE_FOOTER = "}]);";
+var TEMPLATE_HEADER = 'angular.module(\'<%= module %>\'<%= standalone %>).run([\'$templateCache\', function($templateCache) {';
+var TEMPLATE_BODY = '$templateCache.put(\'<%= url %>\',\'<%= contents %>\');';
+var TEMPLATE_FOOTER = '}]);';
 
 var DEFAULT_FILENAME = 'templates.js';
 var DEFAULT_MODULE = 'templates';

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gutil = require('gulp-util');
 var concat = require('gulp-concat');
 var header = require('gulp-header');
 var footer = require('gulp-footer');
-var htmlJsStr = require('js-string-escape');
+var jsesc = require('jsesc');
 
 /**
  * "constants"
@@ -86,7 +86,7 @@ function templateCacheFiles(root, base, templateBody, transformUrl) {
 
     file.contents = new Buffer(gutil.template(template, {
       url: url,
-      contents: htmlJsStr(file.contents),
+      contents: jsesc(file.contents.toString('utf8')),
       file: file
     }));
 

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ var jsesc = require('jsesc');
  * "constants"
  */
 
-var TEMPLATE_HEADER = 'angular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
-var TEMPLATE_BODY = '$templateCache.put("<%= url %>","<%= contents %>");';
-var TEMPLATE_FOOTER = '}]);';
+var TEMPLATE_HEADER = "angular.module('<%= module %>'<%= standalone %>).run(['$templateCache', function($templateCache) {";
+var TEMPLATE_BODY = "$templateCache.put('<%= url %>','<%= contents %>'); ";
+var TEMPLATE_FOOTER = "}]);";
 
 var DEFAULT_FILENAME = 'templates.js';
 var DEFAULT_MODULE = 'templates';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-angular-templatecache",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Concatenates and registers AngularJS templates in the $templateCache.",
   "main": "index.js",
   "scripts": {
@@ -30,12 +30,12 @@
   "license": "MIT",
   "dependencies": {
     "event-stream": "3.x",
-    "path": "0.x",
-    "gulp-util": "3.x",
+    "gulp-concat": "2.x",
     "gulp-footer": "1.x",
     "gulp-header": "1.x",
-    "gulp-concat": "2.x"
+    "gulp-util": "3.x",
     "jsesc": "~1.0.0",
+    "path": "0.x"
   },
   "devDependencies": {
     "mocha": "latest"

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "event-stream": "3.x",
     "path": "0.x",
     "gulp-util": "3.x",
-    "js-string-escape": "~1.0.0",
     "gulp-footer": "1.x",
     "gulp-header": "1.x",
     "gulp-concat": "2.x"
+    "jsesc": "~1.0.0",
   },
   "devDependencies": {
     "mocha": "latest"

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ describe('gulp-angular-templatecache', function () {
     stream.on('data', function (file) {
       assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
       assert.equal(file.relative, 'templates.js');
-      assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");\n$templateCache.put("/template-b.html","<h1 id=\\"template-b\\">I\\\'m template B!</h1>");}]);');
+      assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');\n$templateCache.put(\'/template-b.html\',\'<h1 id="template-b">I\\\'m template B!</h1>\');}]);');
       cb();
     });
 
@@ -40,7 +40,7 @@ describe('gulp-angular-templatecache', function () {
     stream.on('data', function (file) {
       assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
       assert.equal(file.relative, 'templates.js');
-      assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+      assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/views/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
       cb();
     });
 
@@ -64,7 +64,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/views/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -85,7 +85,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("./template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'./template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -106,7 +106,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("./template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'./template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -127,7 +127,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put(".root/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'.root/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -155,7 +155,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/tpl-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/tpl-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -179,7 +179,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/completely/transformed/final","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/completely/transformed/final\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -205,7 +205,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -251,7 +251,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/foobar.js'));
         assert.equal(file.relative, 'foobar.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/views/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -279,7 +279,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/views/test/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/views/test/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -304,7 +304,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/templates/all/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/templates/all/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -331,7 +331,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), '\'use strict\'; module.exports = angular.module("templates", []).run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), '\'use strict\'; module.exports = angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -352,7 +352,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'define([\'angular\'], function(angular) { \'use strict\'; return angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);});');
+        assert.equal(file.contents.toString('utf8'), 'define([\'angular\'], function(angular) { \'use strict\'; return angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);});');
         cb();
       });
 
@@ -373,7 +373,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'import angular from \'angular\'; export default angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put("/template-a.html","<h1 id=\\"template-a\\">I\\\'m template A!</h1>");}]);');
+        assert.equal(file.contents.toString('utf8'), 'import angular from \'angular\'; export default angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -399,7 +399,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'var template = "$templateCache.put("/template-a.html","yoo");";');
+        assert.equal(file.contents.toString('utf8'), 'var template = "$templateCache.put(\'/template-a.html\',\'yoo\');";');
         cb();
       });
 
@@ -424,7 +424,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module("templates").run(["$templateCache", function($templateCache) {$templateCache.put(\'/template-a.html\',\'yoo\');}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'yoo\');}]);');
         cb();
       });
 


### PR DESCRIPTION
Replaced the js-string-escape dependency with jsesc in order to reduce the amount of escaping when HTML templates are converted to JavaScript strings (especially double quote marks - see issue #93).