### PR TITLE
specify explicit versions for package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "event-stream": "3.x",
-    "path": "0.x",
-    "gulp-util": "3.x",
+    "event-stream": "3.3.2",
+    "gulp-util": "3.0.7",
     "js-string-escape": "~1.0.0",
-    "gulp-footer": "1.x",
-    "gulp-header": "1.x",
-    "gulp-concat": "2.x"
+    "gulp-footer": "1.0.5",
+    "gulp-header": "1.8.2",
+    "gulp-concat": "2.6"
   },
   "devDependencies": {
     "mocha": "latest"


### PR DESCRIPTION
also removed unnecessary `path` package.

without these changes all tests fail on node 6.2.0

after updating package.json, reinstalling dependencies and running `mocha tests`, all pass.