### PR TITLE
Changes TEMPLATE_HEADER

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var jsesc = require('jsesc');
  * "constants"
  */
 
-var TEMPLATE_HEADER = 'angular.module(\'<%= module %>\'<%= standalone %>).run([\'$templateCache\', function($templateCache) {';
+var TEMPLATE_HEADER = 'angular.module(\'<%= module %>\'<%= standalone %>, []).run([\'$templateCache\', function($templateCache) {';
 var TEMPLATE_BODY = '$templateCache.put(\'<%= url %>\',\'<%= contents %>\');';
 var TEMPLATE_FOOTER = '}]);';
 


### PR DESCRIPTION
This adds the second (required) argument to `angular.module()` by modifying `TEMPLATE_HEADER`.  
Fixes #143.