### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var es = require('event-stream');
 var path = require('path');
-var gutil = require('gulp-util');
+var through2 = require('through2');
+var lodashTemplate = require('lodash.template');
 var concat = require('gulp-concat');
 var header = require('gulp-header');
 var footer = require('gulp-footer');
@@ -84,7 +85,7 @@ function templateCacheFiles(root, base, templateBody, transformUrl) {
      * Create buffer
      */
 
-    file.contents = new Buffer(gutil.template(template, {
+    file.contents = new Buffer(lodashTemplate(template)({
       url: url,
       contents: jsesc(file.contents.toString('utf8')),
       file: file
@@ -128,7 +129,7 @@ function wrapInModule(moduleSystem) {
   var moduleTemplate = MODULE_TEMPLATES[moduleSystem];
 
   if (!moduleTemplate) {
-    return gutil.noop();
+    return through2.obj();
   }
 
   return es.pipeline(

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "gulp-concat": "2.6.0",
     "gulp-footer": "1.0.5",
     "gulp-header": "1.8.2",
-    "gulp-util": "3.0.7",
-    "jsesc": "2.2.0"
+    "jsesc": "2.2.0",
+    "lodash.template": "^4.4.0",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
-    "mocha": "latest"
+    "mocha": "latest",
+    "vinyl": "^2.1.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var assert = require('assert');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var templateCache = require('../index');
 
 describe('gulp-angular-templatecache', function () {
@@ -16,13 +16,13 @@ describe('gulp-angular-templatecache', function () {
       cb();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: __dirname,
       path: __dirname + '/template-a.html',
       contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
     }));
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: __dirname,
       path: __dirname + '/template-b.html',
       contents: new Buffer('<h1 id="template-b">I\'m template B!</h1>')
@@ -44,7 +44,7 @@ describe('gulp-angular-templatecache', function () {
       cb();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: __dirname,
       path: __dirname + '/template-a.html',
       contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -68,7 +68,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -89,7 +89,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -110,7 +110,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -131,7 +131,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -159,7 +159,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -183,7 +183,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -209,7 +209,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -232,7 +232,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -255,7 +255,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -283,7 +283,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -308,7 +308,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -335,7 +335,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -356,7 +356,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -377,7 +377,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('<h1 id="template-a">I\'m template A!</h1>')
@@ -403,7 +403,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('yoo')
@@ -428,7 +428,7 @@ describe('gulp-angular-templatecache', function () {
         cb();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         base: __dirname,
         path: __dirname + '/template-a.html',
         contents: new Buffer('yoo')


### PR DESCRIPTION
Closes miickel/gulp-angular-templatecache#148