### PR TITLE
Use current LTS node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - '4.2'
+  - "10"
+  - "8"
+  - "6"


### PR DESCRIPTION
Node 4 has been deprecated. The PR updates node to use [current LTS versions](https://github.com/nodejs/Release#release-schedule).