### PR TITLE
Allow empty header and footer

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,8 +171,8 @@ function templateCache(filename, options) {
    * Prepare header / footer
    */
 
-  var templateHeader = options.templateHeader || TEMPLATE_HEADER;
-  var templateFooter = options.templateFooter || TEMPLATE_FOOTER;
+  var templateHeader = 'templateHeader' in options ? options.templateHeader : TEMPLATE_HEADER;
+  var templateFooter = 'templateFooter' in options ? options.templateFooter : TEMPLATE_FOOTER;
 
   /**
    * Build templateCache

--- a/test/test.js
+++ b/test/test.js
@@ -412,6 +412,27 @@ describe('gulp-angular-templatecache', function () {
       stream.end();
     });
 
+    it('should accept empty strings as header and footer', function (cb) {
+      var stream = templateCache('templates.js', {
+        templateHeader: '',
+        templateFooter: ''
+      });
+
+      stream.on('data', function (file) { assert
+        assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
+        assert.equal(file.relative, 'templates.js');
+        assert.equal(file.contents.toString('utf8'), '$templateCache.put(\'/template-a.html\',\'yoo\');');
+        cb();
+      });
+
+      stream.write(new Vinyl({
+        base: __dirname,
+        path: __dirname + '/template-a.html',
+        contents: new Buffer('yoo')
+      }));
+
+      stream.end();
+    });
   });
 
   describe('options.templateBody', function () {


### PR DESCRIPTION
@simonua  - Use "in" instead of "||" since empty string is falsy

Fixes #147 