### PR TITLE
Add trailing separator to file.base if not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,8 @@ function templateCacheFiles(root, base, templateBody, transformUrl, escapeOption
       url = path.join(root, base(file));
     } else {
       if (base === undefined) {
+        // Make sure file.base ends in a separator, to ensure correct relative
+        // path construction (provides compatibility with Gulp 4/Vinyl 2)
         base = file.base += file.base.substr(-1) === path.sep ? "" : path.sep;
       }
       url = path.join(root, file.path.replace(base, ''));

--- a/index.js
+++ b/index.js
@@ -62,7 +62,10 @@ function templateCacheFiles(root, base, templateBody, transformUrl, escapeOption
     if (typeof base === 'function') {
       url = path.join(root, base(file));
     } else {
-      url = path.join(root, file.path.replace(base || file.base, ''));
+      if (base === undefined) {
+        base = file.base += file.base.substr(-1) === path.sep ? "" : path.sep;
+      }
+      url = path.join(root, file.path.replace(base, ''));
     }
 
     if (root === '.' || root.indexOf('./') === 0) {

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ describe('gulp-angular-templatecache', function () {
     stream.on('data', function (file) {
       assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
       assert.equal(file.relative, 'templates.js');
-      assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');\n$templateCache.put(\'/template-b.html\',\'<h1 id="template-b">I\\\'m template B!</h1>\');}]);');
+      assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');\n$templateCache.put(\'template-b.html\',\'<h1 id="template-b">I\\\'m template B!</h1>\');}]);');
       cb();
     });
 
@@ -155,7 +155,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/tpl-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'tpl-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -205,7 +205,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -331,7 +331,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), '\'use strict\'; module.exports = angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
+        assert.equal(file.contents.toString('utf8'), '\'use strict\'; module.exports = angular.module(\'templates\', []).run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -352,7 +352,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'define([\'angular\'], function(angular) { \'use strict\'; return angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);});');
+        assert.equal(file.contents.toString('utf8'), 'define([\'angular\'], function(angular) { \'use strict\'; return angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);});');
         cb();
       });
 
@@ -373,7 +373,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'import angular from \'angular\'; export default angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
+        assert.equal(file.contents.toString('utf8'), 'import angular from \'angular\'; export default angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);');
         cb();
       });
 
@@ -394,7 +394,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(path.normalize(file.path), path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), '(function(){\'use strict\';angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);})();');
+        assert.equal(file.contents.toString('utf8'), '(function(){\'use strict\';angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'<h1 id="template-a">I\\\'m template A!</h1>\');}]);})();');
         cb();
       });
 
@@ -420,7 +420,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'var template = "$templateCache.put(\'/template-a.html\',\'yoo\');";');
+        assert.equal(file.contents.toString('utf8'), 'var template = "$templateCache.put(\'template-a.html\',\'yoo\');";');
         cb();
       });
 
@@ -442,7 +442,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) { assert
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), '$templateCache.put(\'/template-a.html\',\'yoo\');');
+        assert.equal(file.contents.toString('utf8'), '$templateCache.put(\'template-a.html\',\'yoo\');');
         cb();
       });
 
@@ -466,7 +466,7 @@ describe('gulp-angular-templatecache', function () {
       stream.on('data', function (file) {
         assert.equal(file.path, path.normalize(__dirname + '/templates.js'));
         assert.equal(file.relative, 'templates.js');
-        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'/template-a.html\',\'yoo\');}]);');
+        assert.equal(file.contents.toString('utf8'), 'angular.module(\'templates\').run([\'$templateCache\', function($templateCache) {$templateCache.put(\'template-a.html\',\'yoo\');}]);');
         cb();
       });
 


### PR DESCRIPTION
This PR is designed to make the plugin's ability to generate relative paths forwards-compatible with Gulp 4, without affecting current compatibility with Gulp 3. To do this, the system will make sure `file.base` includes a trailing separator, addressing [a change in vinyl](https://github.com/gulpjs/vinyl/commit/9ae7cd10c5423cbad9d38fc6c99960c62ac2f429#diff-c49ce3c4dfcfa830e06789881dd4d5d4).
This affects test results, as they use vinyl directly. However, it doesn't affect the output of the package as used in Gulp 3.

Fixes #164, Fixes #153